### PR TITLE
Add proxy as a valid request option

### DIFF
--- a/lib/request-options.js
+++ b/lib/request-options.js
@@ -10,7 +10,7 @@ var CACHE_HEADERS = ['if-none-match', 'if-modified-since'];
 
 // Returns an options object that can be fed to the request module.
 module.exports = function(req, options, limits) {
-  var requestOptions = _.pick(options, 'method', 'timeout', 'maxRedirects');
+  var requestOptions = _.pick(options, 'method', 'timeout', 'maxRedirects', 'proxy');
 
   // If an explicit method was not specified on the options, then use the
   // method of the inbound request to the proxy.


### PR DESCRIPTION
Sometimes you need to use an outbound proxy to connect to other services. To do this you would have to set the proxy header.

This is useful when hosting an app on a Paas or similar where you don't have static IPs, and would need to connect/proxy to services that use IP whitelisting.
